### PR TITLE
fixed error while loading docker-compose files with 3.0 version tag

### DIFF
--- a/pkg/converter/compose_file.go
+++ b/pkg/converter/compose_file.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/docker/libcompose/config"
 	"github.com/ghodss/yaml"
@@ -40,7 +41,7 @@ func NewComposeFile(buf [][]byte, projectName string) (cf *ComposeFile, err erro
 	}
 
 	loader := &ComposeLoader{}
-	switch composeVersion {
+	switch strings.Split(composeVersion, ".")[0] {
 	case "3":
 		cf, err = loader.LoadVersion3(buf)
 	case "2":

--- a/pkg/converter/compose_file_test.go
+++ b/pkg/converter/compose_file_test.go
@@ -47,6 +47,25 @@ func TestNewComposeV3File(t *testing.T) {
 	}
 }
 
+func TestNewComposeV3dot0File(t *testing.T) {
+	helper := test.NewHelper(t)
+	r := helper.GetTestFile("docker-compose-v3-0.yml")
+	defer r.Close()
+	b, err := ioutil.ReadAll(r)
+	helper.Must(err)
+
+	cf, err := converter.NewComposeFile([][]byte{b}, "")
+	helper.Must(err)
+
+	services := []string{"busy_env"}
+	for _, service := range services {
+		_, found := cf.ServiceConfigs.Get(service)
+		if !found {
+			t.Errorf("Couldn't find service %q", service)
+		}
+	}
+}
+
 func TestNewComposeVersionFile(t *testing.T) {
 	reader := &converter.ComposeReader{}
 	b, err := reader.Read("/testdata/docker-compose-version.yml")

--- a/pkg/converter/linker_test.go
+++ b/pkg/converter/linker_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	sloppy "github.com/sloppyio/cli/pkg/api"
 	"github.com/sloppyio/sloppose/pkg/converter"
 )

--- a/pkg/converter/testdata/docker-compose-v3-0.yml
+++ b/pkg/converter/testdata/docker-compose-v3-0.yml
@@ -1,0 +1,11 @@
+version: "3.0"
+
+services:
+  busy_env:
+    image: busybox
+    env_file: testdata/test.env
+    command: ["sleep", "20"]
+    depends_on:
+      - mongo
+  mongo:
+    image: mongodb

--- a/pkg/converter/yaml_writer_test.go
+++ b/pkg/converter/yaml_writer_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/sloppyio/sloppose/internal/test"
 	"github.com/sloppyio/sloppose/pkg/converter"
 )


### PR DESCRIPTION
This PR is related to https://github.com/sloppyio/sloppose/issues/6. Which will fix the dot-x version declaration. So the real error will appear, which is `Unsupported Compose file version: %#v. The only version supported is "3" (or "3.0")`.