### PR TITLE
make golden input deployable on sloppy.io

### DIFF
--- a/pkg/converter/testdata/docker-compose-v3.yml
+++ b/pkg/converter/testdata/docker-compose-v3.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  busy_env:
+  busybox:
     image: busybox
     env_file: testdata/test.env
     command: ["sleep", "20"]
@@ -54,7 +54,7 @@ services:
    logging:
      driver: syslog
      options:
-       syslog-address: "tcp://192.168.0.42:123"
+       syslog-address: "udp://192.168.0.42:123"
   mongo:
     image: mongodb
 volumes:

--- a/pkg/converter/testdata/golden0.yml
+++ b/pkg/converter/testdata/golden0.yml
@@ -2,7 +2,7 @@ version: v1
 project: sloppy-test
 services:
   apps:
-    busy_env:
+    busybox:
       cmd: sleep 20
       dependencies:
       - ../apps/mongo
@@ -23,7 +23,7 @@ services:
       logging:
         driver: syslog
         options:
-          syslog-address: tcp://192.168.0.42:123
+          syslog-address: udp://192.168.0.42:123
       volumes:
       - container_path: /var/lib/mysql
     mongo:


### PR DESCRIPTION
Two small fixes needed to make the `pkg/converter/testdata/docker-compose-v3.yml` deployable on sloppy.io.

Tried to run tests with Docker, but that failed and I don't know how to set `CGO_ENABLED=1`

```
$ docker run -v $PWD:/go/src/github.com/sloppyio/sloppose --workdir /go/src/github.com/sloppyio/sloppose -e GOOS=darwin golang:1.9.4 make test
go test -v -race -timeout 30s -covermode=atomic -coverprofile=coverage.txt ./pkg/converter
go test: -race requires cgo; enable cgo by setting CGO_ENABLED=1
GNUmakefile:20: recipe for target 'test' failed
make: *** [test] Error 2
```