### PR TITLE
fixed nil ref for number entry in ports list

### DIFF
--- a/pkg/converter/sloppy_file.go
+++ b/pkg/converter/sloppy_file.go
@@ -133,6 +133,8 @@ func NewSloppyFile(cf *ComposeFile) (*SloppyFile, error) {
 				switch entry.(type) { // number, string, obj
 				case string:
 					ports = append(ports, entry.(string))
+				case float64:
+					ports = append(ports, strconv.Itoa(int(entry.(float64))))
 				case int:
 					p := strconv.Itoa(entry.(int))
 					ports = append(ports, p)

--- a/pkg/converter/testdata/docker-compose-v3.yml
+++ b/pkg/converter/testdata/docker-compose-v3.yml
@@ -57,6 +57,8 @@ services:
        syslog-address: "udp://192.168.0.42:123"
   mongo:
     image: mongodb
+    ports:
+      - 27017 # container port
 volumes:
     db:
     content:

--- a/pkg/converter/testdata/golden0.yml
+++ b/pkg/converter/testdata/golden0.yml
@@ -28,6 +28,7 @@ services:
       - container_path: /var/lib/mysql
     mongo:
       image: mongodb
+      port: 27017
     wordpress:
       dependencies:
       - ../apps/db


### PR DESCRIPTION
since its valid in v3 schema to list ports like:
```
ports:
 - 27017
```
this would crash without this fix.
